### PR TITLE
feat: Add real links to footer

### DIFF
--- a/app/(shared)/Footer.tsx
+++ b/app/(shared)/Footer.tsx
@@ -15,8 +15,12 @@ const Footer = () => {
         {/* SECOND COLUMN */}
         <div className="mt-16 basis-1/4 sm:mt-0">
           <h4 className="font-bold">Links</h4>
-          <p className="my-5">GitHub</p>
-          <p className="my-5">LinkedIn</p>
+          <p className="my-5">
+          <a href="https://github.com/diipanshuu">GitHub</a>
+          </p>
+          <p className="my-5">
+          <a href="https://www.linkedin.com/in/diipanshuu">LinkedIn</a>
+          </p>
           <p>Portfolio</p>
         </div>
         {/* THIRD COLUMN */}


### PR DESCRIPTION
Updated the footer component to include the actual links for GitHub and LinkedIn. These links are now clickable and point to the respective webpages.